### PR TITLE
Revert "fix: make flag -o independent of -n"

### DIFF
--- a/main.go
+++ b/main.go
@@ -468,13 +468,12 @@ func handleOutput(rendered string, countTokens bool, encoding string, noClipboar
 			err := utils.CopyToClipboard(rendered)
 			if err == nil {
 				utils.AddMessage("✅", "Copied to clipboard successfully.", color.FgGreen, 5)
-			} else {
-				// If clipboard copy failed, fall back to console output
-				utils.PrintColouredMessage("i", fmt.Sprintf("Failed to copy to clipboard: %v. Falling back to console output.", err), color.FgYellow)
+				return nil
 			}
+			// If clipboard copy failed, fall back to console output
+			utils.PrintColouredMessage("i", fmt.Sprintf("Failed to copy to clipboard: %v. Falling back to console output.", err), color.FgYellow)
 		}
 
-		fmt.Print("output is %s", output)
 		if output != "" {
 			err := utils.WriteToFile(output, rendered)
 			if err != nil {


### PR DESCRIPTION
Reverts sammcj/ingest#53

This caused all the ingested information to be output to the terminal without --output